### PR TITLE
Fix operation within loop or w/ non-interactive use

### DIFF
--- a/R/plot.conf.mat.R
+++ b/R/plot.conf.mat.R
@@ -54,13 +54,16 @@ plotConfmat = function(conf.mat, ordering = NA, labels = FALSE, ...){
     y.values = rev(1:N)
   }
   
-  lattice::levelplot(t(conf.mat.ord)[,ncol(conf.mat.ord):1], col.regions = colors, 
-            xlab = "Loser", ylab = "Winner",
-            scales=list(
+  gobj <- lattice::levelplot(
+    t(conf.mat.ord)[,ncol(conf.mat.ord):1],
+    col.regions = colors, 
+    xlab = "Loser", ylab = "Winner",
+    scales=list(
               x=list(labels=lbls, at = x.values, rot = ifelse(labels == TRUE, 90, 0)),
               y=list(labels=lbls, at = y.values)
-            )
-  )
+    )
+  ) # close lattice
+  print(gobj)
 }
 
 


### PR DESCRIPTION
This patch should permit display of conf.mat into the currently open graphics object (e.g. jpeg file) when executed in script or loop.

See https://stackoverflow.com/questions/7981507/lattice-plots-not-working-inside-a-function and https://stackoverflow.com/questions/26643852/ggplot-plots-in-scripts-do-not-display-in-rstudio

alternatively `return (gobj)` instead of `print (gobj)` so that users can manually modify the chart themselves prior to `print`ing the chart themselves.